### PR TITLE
Wishlist. Added monitor selection and bounding box support. Added small test of each feature in the _demo section.  

### DIFF
--- a/desktopmagic/screengrab_win32.py
+++ b/desktopmagic/screengrab_win32.py
@@ -45,7 +45,6 @@ class BoundingBoxOutOfRange(Exception):
 	Coordinates are too large for the current resolution
 	'''
 
-
 class DIBFailed(Exception):
 	pass
 
@@ -90,11 +89,12 @@ def getDCAndBitMap(saveBmpFilename=None, bbox=None):
 
 	if bbox:
 		left,  top, width, height = bbox
-		
+
 		if (left < left or top < top or 
 			width > width or height > height):
-			raise Exception("Invalid bounding box. Range exceeds" 
-						"available screen area.")	
+			raise BoundingBoxOutOfRange(
+					"Invalid bounding box. Range exceeds" 
+					"available screen area.")	
 
 	# Retrieve the device context (DC) for the entire window.
 	hwndDevice = win32gui.GetWindowDC(hwnd)


### PR DESCRIPTION
As per your wishlist, I added in support for taking a snapshot of a single monitor. It enumerates all the available devices, and allows the user to select which they would like. 

Additionally, I added a boundingBox param while I was in there. In case people just need a small portion of the screen. 

_demo has a small test loop for verifying `saveScreenToBitmap` and `getScreenAsImage` work as intended. 
