### PR TITLE
Now PIL lives in the PIL spacename only, but to support the both ways of...

### DIFF
--- a/desktopmagic/screengrab_win32.py
+++ b/desktopmagic/screengrab_win32.py
@@ -310,7 +310,10 @@ def getBGR32(dc, bitmap):
 
 
 def _getRectAsImage(rect):
-	import Image
+	try:
+		from PIL import Image
+	except:
+		import Image
 
 	dc, bitmap = getDCAndBitMap(rect=rect)
 	try:


### PR DESCRIPTION
... PIL is installed, we have to try import both ways.

Specially if Pillow was installed 
