### PR TITLE
Add function getWindowAsImage to capture single Window

### DIFF
--- a/desktopmagic/screengrab_win32.py
+++ b/desktopmagic/screengrab_win32.py
@@ -425,6 +425,19 @@ def getRectAsImage(rect):
 	return _getRectAsImage(rect)
 
 
+def getWindowAsImage(hwnd = None):
+	"""
+	Returns a PIL Image object (mode RGB) of a Window.
+
+	Raises L{GrabFailed} if unable to take a screenshot (e.g. due to locked
+	workstation, no display, or active UAC elevation screen).
+	"""
+	if hwnd == None:
+		hwnd = win32gui.GetForegroundWindow()
+	rect = win32gui.GetWindowRect(hwnd)
+	return _getRectAsImage(rect)
+
+
 def saveScreenToBmp(bmpFilename):
 	"""
 	Save a screenshot of the entire virtual screen to a .bmp file.  Does not


### PR DESCRIPTION
Added the function getWindowAsImage() to screenshot a specific window. Takes the current window if hwnd == None or any other window specified by the window handle hwnd. With win32gui.EnumWindows one can obtain the window handles of all top-level windows.